### PR TITLE
feat(v0.6): fp8 KV cache 2x capacity, viz tools, watermark admission

### DIFF
--- a/docs/benchmark_logs/bench_kv_cache_fp8_v06.json
+++ b/docs/benchmark_logs/bench_kv_cache_fp8_v06.json
@@ -1,0 +1,16 @@
+[
+  {
+    "kv_dtype": "auto",
+    "model_mem_gb": 18.89,
+    "kv_capacity": 147875,
+    "tps": 943.4,
+    "elapsed_s": 0.271
+  },
+  {
+    "kv_dtype": "fp8",
+    "model_mem_gb": 18.31,
+    "kv_capacity": 282435,
+    "tps": 859.5,
+    "elapsed_s": 0.298
+  }
+]

--- a/docs/release-v0.6.0.md
+++ b/docs/release-v0.6.0.md
@@ -1,0 +1,123 @@
+# Release v0.6.0 — 分页 KV + viz 工具
+
+**Date:** 2026-08-23
+**Branch:** `main`
+**Theme:** FP8 KV 缓存 (2x 容量)、可视化工具 (viz.structure + viz.memory)、KV 水位线准入控制
+
+## Summary
+
+v0.6.0 完成 KV 缓存的 fp8 路径端到端打通（flashdecoding kernel 内 e4m3 dequant +
+attention module 接口 + kv_cache_manager fp8 dtype 支持），使 KV 容量翻倍（147K →
+282K tokens on A10）。新增 `lite_llama.viz` 模块导出模型结构树和显存预算表。
+KVCacheManager 新增 watermark 准入控制和 utilization 指标。
+
+## 1. Feature: FP8 KV Cache (2x capacity)
+
+**核心改动:**
+
+- `flashdecoding.py`: 新增 `KV_FP8` constexpr 路径, `dequant_fp8e4m3` bit-surgery
+  升到 fp32 后乘 scale。调用方将 `FP8_E4M3_BIT_TRICK_SCALE` 折入 scale 免 kernel 内补偿。
+- `modules/attention.py`: 新增 `k_scale`/`v_scale` 参数,传递到 flash_decoding。
+- `modules/quantization/kv_cache.py`: `Fp8KVCacheMethod` 负责 write-side 量化。
+
+**使用方式:**
+
+```bash
+python -m lite_llama.cli chat --model-dir my_weight/Qwen3-0.6B --kv-cache-dtype fp8
+```
+
+**修复前后对比 (Qwen3-0.6B, A10, batch=4, gen_len=64, greedy):**
+
+| KV dtype | KV Capacity | TPS | 相对 fp16 |
+|----------|-------------|-----|-----------|
+| fp16 (default) | 147,875 tok | 943.4 | 1.00x |
+| fp8 (e4m3) | 282,435 tok | 859.5 | 0.91x |
+
+> KV 容量提升 **1.91x**，throughput 仅降 9%（fp8 dequant 额外开销）。
+> 对长序列场景（4K+ context），fp8 KV 是纯收益：原本 OOM 的序列现在能服务。
+
+> Benchmark 日志: [`docs/benchmark_logs/bench_kv_cache_fp8_v06.json`](benchmark_logs/bench_kv_cache_fp8_v06.json)
+
+## 2. Feature: viz.structure (模型结构树)
+
+新增 `lite_llama/viz/structure.py`，遍历 `nn.Module` 树导出缩进文本树，
+显示层类型、参数量和 dtype。
+
+```python
+from lite_llama.viz import export_structure_tree
+tree = export_structure_tree(model, max_depth=3)
+```
+
+输出示例:
+```
+model: Qwen3Model
+├── embed_tokens: Embedding [155,648,000 params, float16]
+├── layers: ModuleList
+│   ├── 0: Qwen3DecoderLayer
+│   │   ├── self_attn: Attention
+│   │   ├── mlp: MLP
+│   ...
+└── norm: RMSNorm [1,024 params, float16]
+```
+
+## 3. Feature: viz.memory (显存预算表)
+
+新增 `lite_llama/viz/memory.py`，从模型配置纯计算得到显存分解（无需 GPU），
+输出 markdown 表格。
+
+```python
+from lite_llama.viz import export_memory_budget
+table = export_memory_budget(
+    num_layers=28, hidden_size=1024, intermediate_size=3072,
+    num_heads=16, num_kv_heads=8, head_dim=64,
+    vocab_size=151936, num_kv_blocks=147875,
+    weight_dtype="fp16", kv_dtype="fp16",
+)
+```
+
+| Component | Size | Percentage |
+|-----------|------|------------|
+| Model Weights | 1.24 GB | 12.8% |
+| KV Cache (fp16) | 7.90 GB | 82.0% |
+| Activations | 0.25 GB | 2.6% |
+| CUDA Graph | 0.25 GB | 2.6% |
+| **Total** | **9.63 GB** | 100% |
+
+## 4. Feature: KV Cache Watermark 准入控制
+
+`KVCacheManager` 新增:
+- `watermark` 参数 (默认 0.1): 当空闲 blocks 低于 `total * watermark` 时拒绝新请求。
+- `can_admit(need_blocks)` 方法: 纯读判断,调度器用于准入决策。
+- `utilization` 属性: 返回当前使用率 (0.0~1.0)。
+
+```python
+if kv_cache.can_admit(seq_len):
+    allocate_and_serve(request)
+else:
+    queue_or_reject(request)
+```
+
+## 5. Chore
+
+| Item | 变更 |
+|------|------|
+| `pyproject.toml` | 版本号 `0.4.0` → `0.6.0` |
+| `flashdecoding.py` | 精简 docstring + fp8 KV cache 用法示例 |
+
+## 6. 测试结果
+
+```
+217 passed, 2 skipped    (CPU subset, gpu/weights tests deselected)
+4 passed                 (golden gate, with weights)
+```
+
+KV cache watermark 和 viz 模块为纯 Python, 无需 GPU 即可验证。
+
+## Upgrade
+
+```bash
+git pull origin main
+uv pip install -e .
+# 使用 fp8 KV cache
+python -m lite_llama.cli chat --model-dir my_weight/Qwen3-0.6B --kv-cache-dtype fp8
+```

--- a/lite_llama/executor/kv_cache_manager.py
+++ b/lite_llama/executor/kv_cache_manager.py
@@ -164,6 +164,7 @@ class KVCacheManager:
         block_size=1,
         dtype=torch.float16,
         device="cuda",
+        watermark: float = 0.1,
     ):
         self.num_layers = num_layers
         self.num_kv_heads = num_kv_heads
@@ -175,6 +176,13 @@ class KVCacheManager:
         self.dtype = dtype
         self.device = device
         self.can_use_mem_size = gpu_num_blocks  # rows currently free
+
+        # Watermark: refuse new requests when free blocks drop below this fraction.
+        self._watermark_blocks = int(gpu_num_blocks * watermark)
+        logger.info(
+            "KV cache: %d blocks, watermark=%d blocks (%.0f%%)",
+            gpu_num_blocks, self._watermark_blocks, watermark * 100,
+        )
 
         # Row indices to hand out, and the per-row reference count.
         self.kv_mem_pos_indexs = torch.arange(
@@ -193,6 +201,21 @@ class KVCacheManager:
 
         # Initialize the gpu_kv_buffer
         self.init_kv_buffers(self.max_num_tokens, head_dim, num_kv_heads, num_layers, dtype, device)
+
+    def can_admit(self, need_blocks: int) -> bool:
+        """Check if a new request requiring *need_blocks* can be admitted.
+
+        Returns False when free capacity after allocation would drop below the
+        watermark, preventing cache pressure from causing eviction cascades.
+        This is a pure read — no allocation happens.
+        """
+        remaining = self.can_use_mem_size - need_blocks
+        return remaining >= self._watermark_blocks
+
+    @property
+    def utilization(self) -> float:
+        """Fraction of KV cache currently in use (0.0 empty, 1.0 full)."""
+        return 1.0 - (self.can_use_mem_size / self.max_num_tokens)
 
     def init_kv_buffers(
         self,

--- a/lite_llama/viz/__init__.py
+++ b/lite_llama/viz/__init__.py
@@ -1,0 +1,20 @@
+"""Visualization tools: structure tree and memory budget table.
+
+Exports readable representations of model architecture and memory allocation
+for debugging and documentation.
+
+Usage:
+    from lite_llama.viz import print_structure_tree, print_memory_budget
+    print_structure_tree(model)
+    print_memory_budget(config, kv_cache_manager)
+"""
+
+from .structure import print_structure_tree, export_structure_tree
+from .memory import print_memory_budget, export_memory_budget
+
+__all__ = [
+    "export_memory_budget",
+    "export_structure_tree",
+    "print_memory_budget",
+    "print_structure_tree",
+]

--- a/lite_llama/viz/memory.py
+++ b/lite_llama/viz/memory.py
@@ -1,0 +1,146 @@
+"""viz.memory: static memory budget table (L1).
+
+Computes and renders a breakdown of GPU memory usage: model weights, KV cache,
+activations, and CUDA graph workspace. Pure computation from config parameters,
+no GPU required.
+
+Usage:
+    table = export_memory_budget(config, num_kv_blocks=100000, kv_dtype="fp16")
+    print_memory_budget(config, num_kv_blocks=100000)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class MemoryBudget:
+    """Static memory breakdown in bytes."""
+
+    model_weights_bytes: int
+    kv_cache_bytes: int
+    activation_bytes: int
+    cuda_graph_bytes: int
+    total_bytes: int
+
+    @property
+    def model_weights_gb(self) -> float:
+        return self.model_weights_bytes / (1024**3)
+
+    @property
+    def kv_cache_gb(self) -> float:
+        return self.kv_cache_bytes / (1024**3)
+
+    @property
+    def total_gb(self) -> float:
+        return self.total_bytes / (1024**3)
+
+
+def _dtype_bytes(dtype_str: str) -> int:
+    """Bytes per element for a dtype string."""
+    return {"fp16": 2, "bf16": 2, "fp32": 4, "int8": 1, "uint8": 1, "fp8": 1, "int4": 1}.get(
+        dtype_str, 2
+    )
+
+
+def compute_memory_budget(
+    num_layers: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    vocab_size: int,
+    num_kv_blocks: int,
+    weight_dtype: str = "fp16",
+    kv_dtype: str = "fp16",
+    max_batch_size: int = 16,
+    max_seq_len: int = 2048,
+) -> MemoryBudget:
+    """Compute static memory budget from model config.
+
+    Args:
+        num_layers: Number of transformer layers.
+        hidden_size: Model hidden dimension.
+        intermediate_size: FFN intermediate dimension.
+        num_heads: Number of attention heads.
+        num_kv_heads: Number of KV heads (GQA).
+        head_dim: Dimension per head.
+        vocab_size: Vocabulary size.
+        num_kv_blocks: KV cache capacity in tokens.
+        weight_dtype: Model weight dtype string.
+        kv_dtype: KV cache dtype string.
+        max_batch_size: Maximum batch size for activation estimate.
+        max_seq_len: Maximum sequence length.
+    """
+    w_bytes = _dtype_bytes(weight_dtype)
+    kv_bytes = _dtype_bytes(kv_dtype)
+
+    # Model weights: embedding + layers + lm_head
+    embed_params = vocab_size * hidden_size
+    # Per layer: qkv_proj + o_proj + gate_proj + up_proj + down_proj + norms
+    qkv_params = hidden_size * (num_heads + 2 * num_kv_heads) * head_dim
+    o_params = num_heads * head_dim * hidden_size
+    ffn_params = hidden_size * intermediate_size * 3  # gate + up + down
+    norm_params = hidden_size * 2  # input_norm + post_norm
+    per_layer_params = qkv_params + o_params + ffn_params + norm_params
+    total_params = embed_params + num_layers * per_layer_params + vocab_size * hidden_size
+    model_bytes = total_params * w_bytes
+
+    # KV cache: 2 (K+V) * num_layers * num_kv_heads * head_dim * num_blocks
+    kv_cache_bytes = 2 * num_layers * num_kv_heads * head_dim * num_kv_blocks * kv_bytes
+
+    # Activation estimate: one forward pass peak (rough upper bound)
+    act_bytes = max_batch_size * max_seq_len * hidden_size * 2 * 4  # fp32 intermediates
+
+    # CUDA graph workspace (conservative estimate)
+    graph_bytes = 256 * 1024 * 1024  # 256 MB
+
+    total = model_bytes + kv_cache_bytes + act_bytes + graph_bytes
+
+    return MemoryBudget(
+        model_weights_bytes=model_bytes,
+        kv_cache_bytes=kv_cache_bytes,
+        activation_bytes=act_bytes,
+        cuda_graph_bytes=graph_bytes,
+        total_bytes=total,
+    )
+
+
+def export_memory_budget(
+    num_layers: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    vocab_size: int,
+    num_kv_blocks: int,
+    weight_dtype: str = "fp16",
+    kv_dtype: str = "fp16",
+    max_batch_size: int = 16,
+    max_seq_len: int = 2048,
+) -> str:
+    """Export memory budget as a markdown table string."""
+    budget = compute_memory_budget(
+        num_layers, hidden_size, intermediate_size, num_heads,
+        num_kv_heads, head_dim, vocab_size, num_kv_blocks,
+        weight_dtype, kv_dtype, max_batch_size, max_seq_len,
+    )
+
+    lines = [
+        "| Component | Size | Percentage |",
+        "|-----------|------|------------|",
+        f"| Model Weights | {budget.model_weights_gb:.2f} GB | {budget.model_weights_bytes/budget.total_bytes*100:.1f}% |",
+        f"| KV Cache ({kv_dtype}) | {budget.kv_cache_gb:.2f} GB | {budget.kv_cache_bytes/budget.total_bytes*100:.1f}% |",
+        f"| Activations | {budget.activation_bytes/(1024**3):.2f} GB | {budget.activation_bytes/budget.total_bytes*100:.1f}% |",
+        f"| CUDA Graph | {budget.cuda_graph_bytes/(1024**3):.2f} GB | {budget.cuda_graph_bytes/budget.total_bytes*100:.1f}% |",
+        f"| **Total** | **{budget.total_gb:.2f} GB** | 100% |",
+    ]
+    return "\n".join(lines)
+
+
+def print_memory_budget(**kwargs) -> None:
+    """Print memory budget table to stdout."""
+    print(export_memory_budget(**kwargs))

--- a/lite_llama/viz/structure.py
+++ b/lite_llama/viz/structure.py
@@ -1,0 +1,93 @@
+"""viz.structure: export model architecture as a text tree (L1).
+
+Walks a torch.nn.Module tree and renders it as an indented text tree showing
+layer types, parameter shapes, and quantisation status.
+
+Usage:
+    tree_str = export_structure_tree(model)
+    print_structure_tree(model)
+"""
+
+from __future__ import annotations
+
+import torch.nn as nn
+
+
+def _format_params(module: nn.Module) -> str:
+    """Summarise parameters of a leaf module."""
+    params = list(module.parameters(recurse=False))
+    if not params:
+        return ""
+    total = sum(p.numel() for p in params)
+    dtypes = {str(p.dtype).replace("torch.", "") for p in params}
+    return f" [{total:,} params, {'/'.join(sorted(dtypes))}]"
+
+
+def _tree_lines(module: nn.Module, prefix: str = "", name: str = "model") -> list[str]:
+    """Recursively build tree lines."""
+    lines: list[str] = []
+    type_name = type(module).__name__
+    param_info = _format_params(module)
+    lines.append(f"{prefix}{name}: {type_name}{param_info}")
+
+    children = list(module.named_children())
+    for i, (child_name, child) in enumerate(children):
+        is_last = i == len(children) - 1
+        connector = "└── " if is_last else "├── "
+        extension = "    " if is_last else "│   "
+        child_lines = _tree_lines(child, prefix=prefix + extension, name=child_name)
+        # Replace first line's prefix with the connector
+        first = f"{prefix}{connector}{child_name}: {type(child).__name__}{_format_params(child)}"
+        lines.append(first)
+        lines.extend(child_lines[1:])  # skip the redundant first line from recursion
+
+    return lines
+
+
+def export_structure_tree(model: nn.Module, max_depth: int = 4) -> str:
+    """Export the model structure as an indented text tree.
+
+    Args:
+        model: The PyTorch model.
+        max_depth: Maximum nesting depth to display.
+
+    Returns:
+        Multi-line string of the tree.
+    """
+    lines: list[str] = []
+    _build_tree(model, lines, prefix="", depth=0, max_depth=max_depth, name="model")
+    return "\n".join(lines)
+
+
+def _build_tree(module: nn.Module, lines: list[str], prefix: str,
+                depth: int, max_depth: int, name: str) -> None:
+    """Recursively build the tree into lines list."""
+    type_name = type(module).__name__
+    param_info = _format_params(module)
+    lines.append(f"{prefix}{name}: {type_name}{param_info}")
+
+    if depth >= max_depth:
+        children = list(module.named_children())
+        if children:
+            lines.append(f"{prefix}    ... ({len(children)} children)")
+        return
+
+    children = list(module.named_children())
+    for i, (child_name, child) in enumerate(children):
+        is_last = i == len(children) - 1
+        connector = "└── " if is_last else "├── "
+        extension = "    " if is_last else "│   "
+        lines.append(f"{prefix}{connector}{child_name}: {type(child).__name__}{_format_params(child)}")
+        # Recurse into grandchildren
+        grandchildren = list(child.named_children())
+        for j, (gc_name, gc) in enumerate(grandchildren):
+            gc_is_last = j == len(grandchildren) - 1
+            gc_connector = "└── " if gc_is_last else "├── "
+            gc_extension = "    " if gc_is_last else "│   "
+            _build_tree(gc, lines, prefix + extension + gc_extension,
+                       depth + 2, max_depth, gc_name)
+
+
+def print_structure_tree(model: nn.Module, max_depth: int = 4) -> None:
+    """Print the model structure tree to stdout."""
+    print(export_structure_tree(model, max_depth=max_depth))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lite-llama"
-version = "0.4.0"
+version = "0.6.0"
 description = "A lightweight, Triton-kernel based LLM inference framework for LLaMA / Qwen / LLaVA / Qwen3-VL"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
- FP8 KV cache end-to-end: flashdecoding e4m3 dequant path delivers 1.91x KV capacity (282K vs 148K tokens on A10) with 9% TPS cost.
- New lite_llama/viz/ package:
  - viz.structure: export model architecture as indented text tree
  - viz.memory: static memory budget table (no GPU needed)
- KVCacheManager: watermark admission control (default 10%), can_admit() method for scheduler-level request gating, utilization property.
- Bump version to 0.6.0; add docs/release-v0.6.0.md with benchmark.
- Benchmark log: docs/benchmark_logs/bench_kv_cache_fp8_v06.json